### PR TITLE
Truncate AWS FailWorkflowExecutionDecisionAttributes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 /.ruby-gemset
 /.ruby-version
+*.sw?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: ruby
+sudo: false
+cache: bundler
 rvm:
-  - jruby-9.0.4.0
+  - jruby-head # 9000
+  - jruby      # 1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - jruby-head # 9000
-  - jruby      # 1.7
+  - jruby-9.0.4.0

--- a/lib/jflow/version.rb
+++ b/lib/jflow/version.rb
@@ -1,3 +1,3 @@
 module JFlow
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/spec/jflow/activity/definition_spec.rb
+++ b/spec/jflow/activity/definition_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 
 describe JFlow::Activity::Definition do
+  let(:swf_client) { JFlow.configuration.swf_client = Aws::SWF::Client.new(stub_responses: true) }
 
   before(:each) do
-    allow(JFlow.configuration.swf_client).to receive(:register_activity_type)
-    allow(JFlow.configuration.swf_client).to receive(:list_activity_types).and_return activity_types
+    swf_client.stub_data(:list_domains)
+    swf_client.stub_data(:list_activity_types)
+    allow(swf_client).to receive(:register_activity_type)
     allow(JFlow.configuration.activity_map).to receive(:add_activity)
   end
 
@@ -16,7 +18,7 @@ describe JFlow::Activity::Definition do
     double(:activity_types, :type_infos => [])
   end
 
-  let(:klass){ "Foo"}
+  let(:klass) { "Foo" }
 
   let(:args) do
     {


### PR DESCRIPTION
From
http://docs.aws.amazon.com/amazonswf/latest/apireference/API_FailWorkflowExecutionDecisionAttributes.html
We need to truncate the errors so we don't create an exception.