### PR TITLE
dump exceptions as yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Class FooActivity
       default_task_schedule_to_start_timeout: "600",
       default_task_schedule_to_close_timeout: "600",
       default_task_start_to_close_timeout: "600",
-      default_task_heartbeat_timeout: "600"
+      default_task_heartbeat_timeout: "600",
+      exceptions_to_exclude: [PermanentError]
     }
   end
 

--- a/jflow.gemspec
+++ b/jflow.gemspec
@@ -6,8 +6,8 @@ require 'jflow/version'
 Gem::Specification.new do |spec|
   spec.name          = "jflow"
   spec.version       = JFlow::VERSION
-  spec.authors       = ["Christophe Verbinnen"]
-  spec.email         = ["christophe.verbinnen@lookout.com"]
+  spec.authors       = ["Christophe Verbinnen","Richard Vorp"]
+  spec.email         = ["christophe.verbinnen@lookout.com","richard.vorp@lookout.com"]
 
   spec.summary       = %q{SWF Flow framework for jRuby}
   spec.description   = %q{you know, for flow}

--- a/lib/jflow/activity/definition.rb
+++ b/lib/jflow/activity/definition.rb
@@ -2,7 +2,11 @@ module JFlow
   module Activity
     class Definition
 
-      DEFAULT_OPTIONS = {}
+      DEFAULT_OPTIONS = {
+        :exceptions_to_exclude => []
+      }
+
+      REGISTRATION_OPTIONS = %i(version domain name default_task_list)
 
       OPTIONS_VALIDATOR = {
         :version => "string",
@@ -10,7 +14,8 @@ module JFlow
         :name    => "string",
         :default_task_list => {
           :name => "string"
-        }
+        },
+        :exceptions_to_exclude => 'array'
       }
 
       attr_reader :options, :klass
@@ -38,7 +43,7 @@ module JFlow
       end
 
       def register_activity
-        JFlow.configuration.swf_client.register_activity_type(options)
+        JFlow.configuration.swf_client.register_activity_type(registration_options)
         JFlow.configuration.logger.info "Activity #{name} was registered successfuly"
       end
 
@@ -76,6 +81,12 @@ module JFlow
       end
 
       private
+
+      def registration_options
+        REGISTRATION_OPTIONS.each_with_object({}) do |key, hash|
+          hash[key] = @options[key]
+        end
+      end
 
       def validate_activity!
         validator = HashValidator.validate(@options, OPTIONS_VALIDATOR)

--- a/lib/jflow/activity/map.rb
+++ b/lib/jflow/activity/map.rb
@@ -16,6 +16,11 @@ module JFlow
         @map[name][version][:class]
       end
 
+      def options_for(name, version)
+        return nil if !@map.has_key?(name) || !@map[name][version]
+        @map[name][version][:options]
+      end
+
     end
   end
 end

--- a/lib/jflow/activity/task.rb
+++ b/lib/jflow/activity/task.rb
@@ -43,6 +43,12 @@ module JFlow
         @klass_value
       end
 
+      def definition_options
+        @definition_options ||= JFlow.configuration.activity_map.options_for(name,version)
+        raise "Could not find activity definition for #{name}, #{version}" unless @definition_options
+        @definition_options
+      end
+
       def method
         if name.split('.').size > 1
           method = name.split('.').last
@@ -67,20 +73,31 @@ module JFlow
         })
       end
 
-
       def failed!(exception)
         log "Task Failed #{exception.message}"
 
         reason = truncate(exception.message, MAX_REASON_SIZE)
 
+        if retryable?(exception)
+          converted_exception = StandardError.new(exception.message)
+          converted_exception.set_backtrace(exception.backtrace)
+        else
+          converted_exception = RuntimeError.new(exception.message)
+          converted_exception.set_backtrace(exception.backtrace)
+        end
+
         swf_client.respond_activity_task_failed(
           task_token: token,
           reason: reason,
-          details: truncate(YAML.dump_stream(exception, exception.backtrace), MAX_DETAILS_SIZE)
+          details: truncate(YAML.dump_stream(converted_exception, exception.backtrace), MAX_DETAILS_SIZE)
         )
       end
 
       private
+
+      def retryable?(exception)
+        !definition_options[:exceptions_to_exclude].include?(exception.class)
+      end
 
       def truncate(message, max_length)
         return message unless message.length > max_length

--- a/lib/jflow/activity/task.rb
+++ b/lib/jflow/activity/task.rb
@@ -72,16 +72,11 @@ module JFlow
         log "Task Failed #{exception.message}"
 
         reason = truncate(exception.message, MAX_REASON_SIZE)
-        details = if exception.backtrace
-                    truncate(exception.backtrace.join("\n"), MAX_DETAILS_SIZE)
-                  else
-                    "no stacktrace"
-                  end
 
         swf_client.respond_activity_task_failed(
           task_token: token,
           reason: reason,
-          details: details
+          details: truncate(YAML.dump_stream(exception, exception.backtrace), MAX_DETAILS_SIZE)
         )
       end
 

--- a/lib/jflow/version.rb
+++ b/lib/jflow/version.rb
@@ -1,3 +1,3 @@
 module JFlow
-  VERSION = "0.3.5"
+  VERSION = "0.4.0"
 end

--- a/spec/jflow/activity/definition_spec.rb
+++ b/spec/jflow/activity/definition_spec.rb
@@ -56,7 +56,9 @@ describe JFlow::Activity::Definition do
                                                     {:name=>"Foo",
                                                      :version=>"1.0",
                                                      :domain=>"foo",
-                                                     :default_task_list=>{:name=>"tasklist"}})
+                                                     :default_task_list=>{:name=>"tasklist"},
+                                                     :exceptions_to_exclude=>[]
+                                                    })
     end
   end
 
@@ -64,7 +66,12 @@ describe JFlow::Activity::Definition do
     it "should register the activity to SWF" do
       definition
       expect(JFlow.configuration.swf_client).to have_received(:register_activity_type)
-                                              .with({:name=>"Foo", :version=>"1.0", :domain=>"foo", :default_task_list=>{:name=>"tasklist"}})
+                                              .with({
+                                                :name=>"Foo",
+                                                :version=>"1.0",
+                                                :domain=>"foo",
+                                                :default_task_list=>{:name=>"tasklist"}
+                                              })
     end
   end
 

--- a/spec/jflow/activity/task_spec.rb
+++ b/spec/jflow/activity/task_spec.rb
@@ -111,7 +111,7 @@ describe JFlow::Activity::Task do
                                               .with({
                                                 :task_token => task.token,
                                                 :reason => "foo",
-                                                :details => "b\na\nr"
+                                                :details => "--- !ruby/object:RSpec::Mocks::Double\n__expired: false\nname: :exception\n---\n- b\n- a\n- r\n"
                                               })
         task.failed!(exception)
       end
@@ -121,7 +121,7 @@ describe JFlow::Activity::Task do
       let(:message) { "X" * 257 }
       let(:backtrace) { ["X" * 32769] }
       let(:exception) { double(:exception,{ :message => message, :backtrace => backtrace } ) }
-      
+
       after { task.failed!(exception) }
 
       it "truncates and adds the truncate message" do
@@ -129,7 +129,7 @@ describe JFlow::Activity::Task do
           .with(
             :task_token => task.token,
             :reason => "#{'X' * 245}[TRUNCATED]",
-            :details => "#{'X' * 32757}[TRUNCATED]"
+            :details => "--- !ruby/object:RSpec::Mocks::Double\n__expired: false\nname: :exception\n---\n- #{'X' * 32679}[TRUNCATED]"
           )
       end
     end


### PR DESCRIPTION
Exception details should be parsed with yaml to aws-flow based deciders can parse the exception and retry.