### PR TITLE
Wrapping exceptions with jflow-exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Class FooActivity
       default_task_schedule_to_start_timeout: "600",
       default_task_schedule_to_close_timeout: "600",
       default_task_start_to_close_timeout: "600",
-      default_task_heartbeat_timeout: "600"
+      default_task_heartbeat_timeout: "600",
+      exceptions_to_exclude: [PermanentError]
     }
   end
 

--- a/jflow.gemspec
+++ b/jflow.gemspec
@@ -6,8 +6,8 @@ require 'jflow/version'
 Gem::Specification.new do |spec|
   spec.name          = "jflow"
   spec.version       = JFlow::VERSION
-  spec.authors       = ["Christophe Verbinnen"]
-  spec.email         = ["christophe.verbinnen@lookout.com"]
+  spec.authors       = ["Christophe Verbinnen","Richard Vorp"]
+  spec.email         = ["christophe.verbinnen@lookout.com","richard.vorp@lookout.com"]
 
   spec.summary       = %q{SWF Flow framework for jRuby}
   spec.description   = %q{you know, for flow}
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "aws-sdk", "~> 2"
   spec.add_runtime_dependency "hash_validator", "~> 0.4"
+  spec.add_runtime_dependency "jflow_exceptions", "~> 0.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/jflow.rb
+++ b/lib/jflow.rb
@@ -3,6 +3,7 @@ require "json"
 require "hash_validator"
 require 'aws-sdk'
 require 'logger'
+require 'jflow_exceptions'
 require "jflow/version"
 require "jflow/configuration.rb"
 require "jflow/domain.rb"

--- a/lib/jflow/activity/definition.rb
+++ b/lib/jflow/activity/definition.rb
@@ -2,7 +2,11 @@ module JFlow
   module Activity
     class Definition
 
-      DEFAULT_OPTIONS = {}
+      DEFAULT_OPTIONS = {
+        :exceptions_to_exclude => []
+      }
+
+      REGISTRATION_OPTIONS = [:version, :domain, :name, :default_task_list]
 
       OPTIONS_VALIDATOR = {
         :version => "string",
@@ -10,7 +14,8 @@ module JFlow
         :name    => "string",
         :default_task_list => {
           :name => "string"
-        }
+        },
+        :exceptions_to_exclude => 'array'
       }
 
       attr_reader :options, :klass
@@ -38,7 +43,7 @@ module JFlow
       end
 
       def register_activity
-        JFlow.configuration.swf_client.register_activity_type(options)
+        JFlow.configuration.swf_client.register_activity_type(registration_options)
         JFlow.configuration.logger.info "Activity #{name} was registered successfuly"
       end
 
@@ -76,6 +81,12 @@ module JFlow
       end
 
       private
+
+      def registration_options
+        REGISTRATION_OPTIONS.each_with_object({}) do |key, hash|
+          hash[key] = @options[key]
+        end
+      end
 
       def validate_activity!
         validator = HashValidator.validate(@options, OPTIONS_VALIDATOR)

--- a/lib/jflow/activity/map.rb
+++ b/lib/jflow/activity/map.rb
@@ -16,6 +16,11 @@ module JFlow
         @map[name][version][:class]
       end
 
+      def options_for(name, version)
+        return nil if !@map.has_key?(name) || !@map[name][version]
+        @map[name][version][:options]
+      end
+
     end
   end
 end

--- a/lib/jflow/version.rb
+++ b/lib/jflow/version.rb
@@ -1,3 +1,3 @@
 module JFlow
-  VERSION = "0.3.6"
+  VERSION = "0.4.0"
 end

--- a/spec/jflow/activity/definition_spec.rb
+++ b/spec/jflow/activity/definition_spec.rb
@@ -56,7 +56,9 @@ describe JFlow::Activity::Definition do
                                                     {:name=>"Foo",
                                                      :version=>"1.0",
                                                      :domain=>"foo",
-                                                     :default_task_list=>{:name=>"tasklist"}})
+                                                     :default_task_list=>{:name=>"tasklist"},
+                                                     :exceptions_to_exclude=>[]
+                                                    })
     end
   end
 
@@ -64,7 +66,12 @@ describe JFlow::Activity::Definition do
     it "should register the activity to SWF" do
       definition
       expect(JFlow.configuration.swf_client).to have_received(:register_activity_type)
-                                              .with({:name=>"Foo", :version=>"1.0", :domain=>"foo", :default_task_list=>{:name=>"tasklist"}})
+                                              .with({
+                                                :name=>"Foo",
+                                                :version=>"1.0",
+                                                :domain=>"foo",
+                                                :default_task_list=>{:name=>"tasklist"}
+                                              })
     end
   end
 


### PR DESCRIPTION
Wrapping exceptions as either JFlow::Exceptions::Common for retryable
exceptions and JFlow::Exceptions::Fatal for fatal exceptions

* Bumping version.
* Exceptions are serialized into yaml
* Wrap exceptions as known ruby exceptions for yaml serialization/deserialization to work
* exceptions_to_exclude option added to activity definition