### PR TITLE
excluding custom options from activity registration 

### DIFF
--- a/lib/jflow/activity/definition.rb
+++ b/lib/jflow/activity/definition.rb
@@ -6,7 +6,7 @@ module JFlow
         :exceptions_to_exclude => []
       }
 
-      REGISTRATION_OPTIONS = [:version, :domain, :name, :default_task_list]
+      JFLOW_OPTIONS = [:exceptions_to_exclude]
 
       OPTIONS_VALIDATOR = {
         :version => "string",
@@ -83,8 +83,8 @@ module JFlow
       private
 
       def registration_options
-        REGISTRATION_OPTIONS.each_with_object({}) do |key, hash|
-          hash[key] = @options[key]
+        @options.reject do |key,value|
+          JFLOW_OPTIONS.include?(key)
         end
       end
 

--- a/lib/jflow/version.rb
+++ b/lib/jflow/version.rb
@@ -1,3 +1,3 @@
 module JFlow
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
excluding custom options from activity registration instead of including known flow options
