### PR TITLE
Execute error handlers on task exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Example of a worker.json
 }
 ```
 
+### Error Handlers
+
+You can attach your own error handler for error logging or exception handling by providing a service that responds to `call(exception)`. If you are using Sentry, you can add Raven as error handler:
+
+```ruby
+JFlow.configuration.error_handlers << Proc.new { |e| Raven.capture_exception(e) }
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/jflow/activity/task.rb
+++ b/lib/jflow/activity/task.rb
@@ -91,6 +91,17 @@ module JFlow
         )
       end
 
+      def handle_exception(exception)
+        JFlow.configuration.error_handlers.each do |error_handler|
+          begin
+            error_handler.call(exception)
+          rescue => e
+            log_error("Error handler failed!")
+            log_error(e.backtrace.join("\n")) unless e.backtrace.nil?
+          end
+        end
+      end
+
       private
 
       def retryable?(exception)
@@ -112,6 +123,10 @@ module JFlow
 
       def log(str)
         JFlow.configuration.logger.info "[#{Thread.current.object_id}] #{str}"
+      end
+
+      def log_error(str)
+        JFlow.configuration.logger.error "[#{Thread.current.object_id}] #{str}"
       end
     end
   end

--- a/lib/jflow/activity/worker.rb
+++ b/lib/jflow/activity/worker.rb
@@ -45,6 +45,7 @@ module JFlow
           Thread.current.set_state(:working)
           task.run!
         rescue => exception
+          task.handle_exception(exception)
           task.failed!(exception)
         end
       end

--- a/lib/jflow/configuration.rb
+++ b/lib/jflow/configuration.rb
@@ -1,7 +1,7 @@
 module JFlow
   class Configuration
 
-    attr_accessor :swf_client, :load_paths, :logger, :activity_map, :cloudwatch_client
+    attr_accessor :swf_client, :load_paths, :logger, :activity_map, :cloudwatch_client, :error_handlers
 
     def initialize
       @swf_client        = nil
@@ -9,6 +9,7 @@ module JFlow
       @load_paths        = []
       @logger            = Logger.new(STDOUT)
       @activity_map      = JFlow::Activity::Map.new
+      @error_handlers    = []
     end
   end
 end

--- a/lib/jflow/version.rb
+++ b/lib/jflow/version.rb
@@ -1,3 +1,3 @@
 module JFlow
-  VERSION = "0.4.5"
+  VERSION = "0.5.0"
 end

--- a/spec/jflow/activity/worker_spec.rb
+++ b/spec/jflow/activity/worker_spec.rb
@@ -26,6 +26,15 @@ describe JFlow::Activity::Worker do
     it "should call failed on exceptions" do
       error = RuntimeError.new("foo")
       expect(task).to receive(:run!).and_raise error
+      expect(task).to receive(:handle_exception).with error
+      expect(task).to receive(:failed!).with error
+      worker.process(task)
+    end
+
+    it "should execute error handlers on exceptions" do
+      error = RuntimeError.new("foo")
+      expect(task).to receive(:run!).and_raise error
+      expect(task).to receive(:handle_exception).with error
       expect(task).to receive(:failed!).with error
       worker.process(task)
     end


### PR DESCRIPTION
Example: JFlow.configuration.error_handlers << Proc.new { |e| Raven.capture_exception(e) }