### PR TITLE
safer maintenance thread.

### DIFF
--- a/lib/jflow.rb
+++ b/lib/jflow.rb
@@ -39,4 +39,19 @@ module JFlow
       end
     end
   end
+
+  def self.handle_exception(exception)
+    JFlow.configuration.error_handlers.each do |error_handler|
+      begin
+        error_handler.call(exception)
+      rescue => e
+        log_error("Error handler failed!")
+        log_error(e.backtrace.join("\n")) unless e.backtrace.nil?
+      end
+    end
+  end
+
+  def self.log_error(str)
+    JFlow.configuration.logger.error "[#{Thread.current.object_id}] #{str}"
+  end
 end

--- a/lib/jflow/activity/task.rb
+++ b/lib/jflow/activity/task.rb
@@ -92,14 +92,7 @@ module JFlow
       end
 
       def handle_exception(exception)
-        JFlow.configuration.error_handlers.each do |error_handler|
-          begin
-            error_handler.call(exception)
-          rescue => e
-            log_error("Error handler failed!")
-            log_error(e.backtrace.join("\n")) unless e.backtrace.nil?
-          end
-        end
+        JFlow.handle_exception(exception)
       end
 
       private

--- a/lib/jflow/activity/worker.rb
+++ b/lib/jflow/activity/worker.rb
@@ -45,6 +45,7 @@ module JFlow
           Thread.current.set_state(:working)
           task.run!
         rescue => exception
+          Thread.current.set_state(:polling)
           task.handle_exception(exception)
           task.failed!(exception)
         end

--- a/lib/jflow/cli.rb
+++ b/lib/jflow/cli.rb
@@ -70,9 +70,14 @@ module JFlow
         protector = JFlow::TerminationProtector.new
         loop do
           break if Thread.current.marked_for_shutdown?
-          protector.set_protection(should_protect?) if is_ec2_instance?
-          stats.tick if enable_stats
-          sleep 30
+          begin
+            protector.set_protection(should_protect?) if is_ec2_instance?
+            stats.tick if enable_stats
+            sleep 30
+          rescue => e
+            JFlow.handle_exception(e)
+            sleep 180
+          end
         end
       end
     end

--- a/lib/jflow/termination_protector.rb
+++ b/lib/jflow/termination_protector.rb
@@ -1,6 +1,5 @@
 require 'net/http'
 require 'json'
-
 module JFlow
   class TerminationProtector
 
@@ -18,7 +17,6 @@ module JFlow
     end
 
     def get_asg_name
-      ec2_client = Aws::EC2::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
       instance_tags = ec2_client.describe_tags(filters: [
         {
           name: "resource-id",
@@ -32,9 +30,12 @@ module JFlow
     end
 
     def set_protection(protect_status)
+      @previous_protect_status ||= false
+      return if @previous_protect_status == protect_status
+      @previous_protect_status = protect_status
+
       JFlow.configuration.logger.debug "Setting termination protection status to #{protect_status} for instance #{instance_id} in region #{region}"
       begin
-        asg_client = Aws::AutoScaling::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
         asg_client.set_instance_protection({
           instance_ids: [instance_id],
           auto_scaling_group_name: get_asg_name,
@@ -42,8 +43,24 @@ module JFlow
         })
       rescue => e
         JFlow.configuration.logger.debug "Something went wrong setting termination proection: #{e.inspect}"
+        JFlow.handle_exception(e)
       end
     end
 
+    def asg_client=(asg_client)
+      @asg_client = asg_client
+    end
+
+    def asg_client
+      @asg_client ||= Aws::AutoScaling::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
+    end
+
+    def ec2_client=(ec2_client)
+      @ec2_client = ec2_client
+    end
+
+    def ec2_client
+      @ec2_client ||= Aws::EC2::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
+    end
   end
 end

--- a/lib/jflow/termination_protector.rb
+++ b/lib/jflow/termination_protector.rb
@@ -3,6 +3,13 @@ require 'json'
 module JFlow
   class TerminationProtector
 
+    attr_accessor :asg_client, :ec2_client
+
+    def initialize(asg_client = nil, ec2_client = nil)
+      @asg_client = asg_client || Aws::AutoScaling::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
+      @ec2_client = ec2_client || Aws::EC2::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
+    end
+
     def region
       instance_data['region']
     end
@@ -45,22 +52,6 @@ module JFlow
         JFlow.configuration.logger.debug "Something went wrong setting termination proection: #{e.inspect}"
         JFlow.handle_exception(e)
       end
-    end
-
-    def asg_client=(asg_client)
-      @asg_client = asg_client
-    end
-
-    def asg_client
-      @asg_client ||= Aws::AutoScaling::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
-    end
-
-    def ec2_client=(ec2_client)
-      @ec2_client = ec2_client
-    end
-
-    def ec2_client
-      @ec2_client ||= Aws::EC2::Client.new(region: region, credentials: Aws::InstanceProfileCredentials.new)
     end
   end
 end

--- a/lib/jflow/version.rb
+++ b/lib/jflow/version.rb
@@ -1,3 +1,3 @@
 module JFlow
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/spec/jflow/termination_protector_spec.rb
+++ b/spec/jflow/termination_protector_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe JFlow::TerminationProtector do
+  subject { described_class.new }
+  let(:aws_autoscaling_client) { Aws::AutoScaling::Client.new(stub_responses: true) }
+  let(:aws_ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
+  let(:instance_identity) do
+    {
+      "availabilityZone" => "us-west-2b",
+      "instanceType" => "m3.large",
+      "imageId" => "ami-464da726",
+      "region" => "us-west-2",
+      "instanceId" => "foobar"
+    }.to_json
+  end
+
+  before do
+    subject.ec2_client = aws_ec2_client
+    subject.asg_client = aws_autoscaling_client
+    allow(Net::HTTP).to receive(:get).and_return(instance_identity)
+    aws_ec2_client.stub_responses(:describe_tags, tags: [{key: 'aws:autoscaling:groupName', resource_id: 'foobar', resource_type: 'instance', value: 'some_asg_name'}])
+  end
+
+  describe "#set_protection" do
+    context "call more than once" do
+      it "set_instance_protection once for true" do
+        expect(aws_autoscaling_client).to receive(:set_instance_protection).with({instance_ids: ['foobar'], auto_scaling_group_name: 'some_asg_name', protected_from_scale_in: true}).once
+        subject.set_protection(true)
+        subject.set_protection(true)
+      end
+
+      it "set_instance_protection once for false" do
+        expected_slace_in_args = {instance_ids: ['foobar'], auto_scaling_group_name: 'some_asg_name', protected_from_scale_in: true}
+        expected_scale_out_args = {instance_ids: ['foobar'], auto_scaling_group_name: 'some_asg_name', protected_from_scale_in: false}
+
+        expect(aws_autoscaling_client).to receive(:set_instance_protection).with(expected_slace_in_args).once
+        expect(aws_autoscaling_client).to receive(:set_instance_protection).with(expected_scale_out_args).once
+
+        subject.set_protection(true)
+        subject.set_protection(false)
+        subject.set_protection(false)
+      end
+    end
+  end
+end

--- a/spec/jflow/termination_protector_spec.rb
+++ b/spec/jflow/termination_protector_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe JFlow::TerminationProtector do
-  subject { described_class.new }
+  subject { described_class.new(aws_autoscaling_client, aws_ec2_client) }
   let(:aws_autoscaling_client) { Aws::AutoScaling::Client.new(stub_responses: true) }
   let(:aws_ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
   let(:instance_identity) do
@@ -15,8 +15,6 @@ describe JFlow::TerminationProtector do
   end
 
   before do
-    subject.ec2_client = aws_ec2_client
-    subject.asg_client = aws_autoscaling_client
     allow(Net::HTTP).to receive(:get).and_return(instance_identity)
     aws_ec2_client.stub_responses(:describe_tags, tags: [{key: 'aws:autoscaling:groupName', resource_id: 'foobar', resource_type: 'instance', value: 'some_asg_name'}])
   end


### PR DESCRIPTION
- rescue put around maintenant thread run for rate limiting errors
  - sleep longer
  - report errors to error handlers
- termination_protector will cache the presumed scale_in and not call API needlessly
